### PR TITLE
Added getblocksysfee to core rpc server.  

### DIFF
--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -89,30 +89,30 @@ namespace Neo.Network.RPC
                     }
                 case "getblockcount":
                     return Blockchain.Default.Height + 1;
-				case "getblockhash":
-					{
-						uint height = (uint)_params[0].AsNumber();
-						if (height >= 0 && height <= Blockchain.Default.Height)
-						{
-							return Blockchain.Default.GetBlockHash(height).ToString();
-						}
-						else
-						{
-							return "Invalid height";
-						}
-					}
-				case "getblocksysfee":
-					{
-						uint height = (uint)_params[0].AsNumber();
-						if (height >= 0 && height <= Blockchain.Default.Height)
-						{
-							return Blockchain.Default.GetSysFeeAmount(height).ToString();
-						}
-						else
-						{
-							return "Invalid height";
-						}
-					}
+                case "getblockhash":
+                    {
+                        uint height = (uint)_params[0].AsNumber();
+                        if (height >= 0 && height <= Blockchain.Default.Height)
+                        {
+                            return Blockchain.Default.GetBlockHash(height).ToString();
+                        }
+                        else
+                        {
+                            return "Invalid height";
+                        }
+                    }
+                case "getblocksysfee":
+                    {
+                        uint height = (uint)_params[0].AsNumber();
+                        if (height >= 0 && height <= Blockchain.Default.Height)
+                        {
+                            return Blockchain.Default.GetSysFeeAmount(height).ToString();
+                        }
+                        else
+                        {
+                            return "Invalid height";
+                        }
+                    }
                 case "getconnectioncount":
                     return LocalNode.RemoteNodeCount;
                 case "getrawmempool":

--- a/neo/Network/RPC/RpcServer.cs
+++ b/neo/Network/RPC/RpcServer.cs
@@ -89,11 +89,30 @@ namespace Neo.Network.RPC
                     }
                 case "getblockcount":
                     return Blockchain.Default.Height + 1;
-                case "getblockhash":
-                    {
-                        uint height = (uint)_params[0].AsNumber();
-                        return Blockchain.Default.GetBlockHash(height).ToString();
-                    }
+				case "getblockhash":
+					{
+						uint height = (uint)_params[0].AsNumber();
+						if (height >= 0 && height <= Blockchain.Default.Height)
+						{
+							return Blockchain.Default.GetBlockHash(height).ToString();
+						}
+						else
+						{
+							return "Invalid height";
+						}
+					}
+				case "getblocksysfee":
+					{
+						uint height = (uint)_params[0].AsNumber();
+						if (height >= 0 && height <= Blockchain.Default.Height)
+						{
+							return Blockchain.Default.GetSysFeeAmount(height).ToString();
+						}
+						else
+						{
+							return "Invalid height";
+						}
+					}
                 case "getconnectioncount":
                     return LocalNode.RemoteNodeCount;
                 case "getrawmempool":


### PR DESCRIPTION
-also added a check for a valid block height for `getblocksysfee` and `getblockhash` cases

This is for the light wallet and any other applications that need to calculate claim transaction amounts in order use `sendrawtransaction` to make a claim.

usage: send a block height (example 204651)
send > `{"jsonrpc": "2.0", "method": "getblocksysfee", "params": [204651], "id": 4}`
receive back > `{"jsonrpc":"2.0","id":4,"result":"1470"}`
